### PR TITLE
Update workflows with v3 actions + permissions

### DIFF
--- a/.github/workflows/gh-pages-workflow.yml
+++ b/.github/workflows/gh-pages-workflow.yml
@@ -5,32 +5,36 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
+concurrency:
+  group: gh-pages-workflow
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v3
 
-    - name: Read .nvmrc
-      run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      id: nvm
-
-    - name: Use Node.js (.nvmrc)
-      uses: actions/setup-node@v1
+    - name: Use Node.js
+      uses: actions/setup-node@v3
       with:
-        node-version: "${{ steps.nvm.outputs.NVMRC }}"
+        node-version-file: .nvmrc
+        cache: npm
 
-    - name: Install dependencies
-      run: npm ci
-
-    - name: Build bundled embed script
-      run: npm run build
+    - name: Install dependencies, test, and build
+      run: |
+        npm ci
+        npm test
+        npm run build
 
     - name: Deploy master to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@2.0.0
-      env:
-        ACCESS_TOKEN: ${{ secrets.DEV_GITHUB_TOKEN }}
-        BASE_BRANCH: master
-        BRANCH: gh-pages
-        FOLDER: build
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: dist
+        clean: true
+        single-commit: true

--- a/.github/workflows/testing-workflow.yml
+++ b/.github/workflows/testing-workflow.yml
@@ -7,19 +7,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v3
 
-    - name: Read .nvmrc
-      run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      id: nvm
-
-    - name: Use Node.js (.nvmrc)
-      uses: actions/setup-node@v1
+    - name: Use Node.js
+      uses: actions/setup-node@v3
       with:
-        node-version: "${{ steps.nvm.outputs.NVMRC }}"
+        node-version-file: .nvmrc
+        cache: npm
 
-    - name: Install dependencies
-      run: npm ci
-
-    - name: Test source code
-      run: npm test
+    - name: Install dependencies, test, and build
+      run: |
+        npm ci
+        npm test
+        npm run build


### PR DESCRIPTION
## Type of Change

- **Something else:** Actions workflows

## What issue does this relate to?

cc https://github.com/do-community/do-bulma/pull/53

### What should this PR do?

Updates Actions workflows to use checkout/setup-node@v3, use github-pages-deploy-action@v4 (which no longer needs a custom token), and sets the Pages workflow to explicitly include write access to the contents so it can deploy.

### What are the acceptance criteria?

Workflows continue to run.