### PR TITLE
Fix embed matching for single 0-indexed test attribute

### DIFF
--- a/src/embed.js
+++ b/src/embed.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,8 +29,11 @@ export default class GlobEmbed {
         // Save the elm
         this.element = element;
 
-        // Get the gob string and remove from elm
+        // Get the glob string and check we have it
         this.glob = element.getAttribute('data-glob-string');
+        if (!this.glob) throw new Error('Glob Embed missing required data-glob-string attribute');
+
+        // Clear out the attributes we don't need
         element.removeAttribute('data-glob-tool-embed');
         element.removeAttribute('data-glob-string');
 
@@ -42,6 +45,7 @@ export default class GlobEmbed {
                 element.removeAttribute(attr.name);
             }
         }
+        if (!this.tests.length) throw new Error('Glob Embed missing required data-glob-test-[0-9]+ attribute(s)');
 
         // Prep results store
         this.results = [];

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ window.GlobToolEmbeds = scope => {
     scope = scope || document;
 
     // Detect all valid embeds to run
-    const embedsElms = Array.from(scope.querySelectorAll('[data-glob-tool-embed][data-glob-string][data-glob-test-1]'));
+    const embedsElms = Array.from(scope.querySelectorAll('[data-glob-tool-embed]'));
 
     // Convert to GlobEmbed instances
     const embeds = embedsElms.map(x => new GlobEmbed(x));


### PR DESCRIPTION
## Type of Change

- **Embed Source:** Element matching

## What issue does this relate to?

N/A

### What should this PR do?

In a situation where an embed was generated that contained a single test, and the integer assigned to the test was `0` (or any value other than `1`), the embed would not render.

This PR changes the logic, so the initial embed detection just relies on the `data-glob-tool-embed` attribute alone, with the `data-glob-string` and `data-glob-test-*` attributes only being searched for (and validated) in the embed constructor.

### What are the acceptance criteria?

Demo continues to work, and if the demo is edited to have a single `data-glob-test-0="hello.js"` attribute (alongside the `data-glob-tool-embed` + `data-glob-string`), it also continues to work.
